### PR TITLE
fixed OpenSSH link

### DIFF
--- a/floppy/openssh.bat
+++ b/floppy/openssh.bat
@@ -4,7 +4,7 @@
 
 title Installing Openssh. Please wait...
 
-if not defined OPENSSH_URL set OPENSSH_URL=http://www.mls-software.com/files/setupssh-7.2p2-1-v1.exe
+if not defined OPENSSH_URL set OPENSSH_URL=https://www.mls-software.com/files/setupssh-7.4p1-1.exe
 if not defined SSHD_PASSWORD  set SSHD_PASSWORD=D@rj33l1ng
 
 for %%i in (%OPENSSH_URL%) do set OPENSSH_EXE=%%~nxi


### PR DESCRIPTION
The link to download the OpenSSH client was not valid anymore. 